### PR TITLE
Upgrade to Rust 2021 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "op-export"
 version = "0.1.0"
 authors = ["Peter Schuller <peter.schuller@infidyne.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 clap = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::process::Command;
 use std::sync::Arc;
 use std::thread;
+use rand::prelude::*;
 
 #[derive(Eq, PartialEq, Debug)]
 struct Item {
@@ -157,9 +158,9 @@ impl Op for ToolOp {
                         return Err(e);
                     }
 
-                    use rand::Rng;
+                    let mut rng = rand::rng();
                     let backoff_time =
-                        rand::thread_rng().gen_range((tries * 3000)..((tries + 1) * 3000));
+                        rng.random_range((tries * 3000)..((tries + 1) * 3000));
 
                     if self.backoff {
                         println!("get item: backing off: {}ms", backoff_time);


### PR DESCRIPTION
This commit upgrades the project from Rust 2018 to Rust 2021 edition.

Changes include:
- Updated `Cargo.toml` to specify `edition = "2021"`.
- Ran `cargo fix --edition` to apply automatic migration changes.
- Addressed warnings from the `rand` crate by updating deprecated function calls in `src/main.rs`:
    - Replaced `rand::thread_rng()` with `rand::rng()`.
    - Replaced `rng.gen_range()` with `rng.random_range()`.
    - Added `use rand::prelude::*;`.
